### PR TITLE
Fix default import

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@workbase/mui-rte",
   "version": "1.26.3",
   "description": "Material-UI Rich Text Editor and Viewer",
-  "type": "module",
   "keywords": [
     "material-ui",
     "rich text editor",

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect, useState, useRef, 
+import React, { FunctionComponent, useEffect, useState, useRef,
     forwardRef, useImperativeHandle, RefForwardingComponent } from 'react'
 import Immutable from 'immutable'
 import classNames from 'classnames'
@@ -7,7 +7,7 @@ import Paper from '@material-ui/core/Paper'
 import {
     EditorState, convertFromRaw, RichUtils, AtomicBlockUtils,
     CompositeDecorator, convertToRaw, DefaultDraftBlockRenderMap, DraftBlockRenderMap, DraftEditorCommand,
-    DraftHandleValue, DraftStyleMap, ContentBlock, DraftDecorator, getVisibleSelectionRect,
+    DraftHandleValue, DraftStyleMap, ContentBlock, DraftDecorator,
     SelectionState, KeyBindingUtil, getDefaultKeyBinding, Modifier
 } from 'draft-js'
 import Editor from 'draft-js-plugins-editor';
@@ -464,8 +464,8 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
     }
 
     const insertAutocompleteSuggestionAsText = (selection: SelectionState, value: string) => {
-        const currentContentState = editorState.getCurrentContent()
-        const entityKey = currentContentState.createEntity("AC_ITEM", 'IMMUTABLE').getLastCreatedEntityKey()
+        // const currentContentState = editorState.getCurrentContent()
+        // const entityKey = currentContentState.createEntity("AC_ITEM", 'IMMUTABLE').getLastCreatedEntityKey()
         const contentState = Modifier.replaceText(editorStateRef.current!.getCurrentContent(),
             selection,
             value)


### PR DESCRIPTION
This line in specific was what was preventing that. With it removed we can go back to `import MUIRichTextEditor from 'mui-rte'`

Also commented out the other lines because they're unused so were causing errors when running `npm t`

Lastly, once this is merged we should do a version bump and publish to our npm repo, then bump in our main repo.